### PR TITLE
Add the official Lamplit Labs X link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are two configuraiton file
     "facebook": "",
     "snapchat": "",
     "tiktok": "",
-    "twitter": "",
+    "x": "",
     "youtube": ""
   }
 }

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -191,6 +191,7 @@ export function getSocialIcon(brand: string) {
         case "github": return GitHubIcon;
         case "linkedin": return LinkedInIcon;
         case "instagram": return InstagramIcon;
+        case "x": return TwitterIcon;
         case "blog": return BlogIcon;
         case "web": return GlobeIcon;
         case "youtube": return YouTubeIcon;

--- a/components/social.tsx
+++ b/components/social.tsx
@@ -24,7 +24,7 @@ const item = {
 
 const socialOrder = [
     "web", "github", "blog", "linkedin", "instagram",
-    "twitter", "youtube", "facebook", "tiktok", "snapchat",
+    "x", "twitter", "youtube", "facebook", "tiktok", "snapchat",
 ] as const;
 
 export const Social = ({ socialLink }: SocialProps) => {

--- a/data/config.json
+++ b/data/config.json
@@ -8,6 +8,7 @@
         "linkedin": "https://www.linkedin.com/company/lamplitlabs",
         "blog": "https://blogs.lamplitlabs.com",
         "web": "https://www.lamplitlabs.com",
-        "github": "https://github.com/lamplitlabs"
+        "github": "https://github.com/lamplitlabs",
+        "x": "https://x.com/lamplitlabs"
     }
 }

--- a/types/appConfig.ts
+++ b/types/appConfig.ts
@@ -17,4 +17,5 @@ export type SocialLink = {
     youtube?: string;
     web?: string;
     github?: string;
+    x?: string;
 };


### PR DESCRIPTION
## Summary
- add https://x.com/lamplitlabs exactly once to each existing organization social list touched in this repository
- leave unrelated content and repositories without social surfaces unchanged
- keep retired Mastodon and Threads account links absent

## Validation
- Production build passed